### PR TITLE
Improved Regex for CodePen URLs

### DIFF
--- a/src/services.js
+++ b/src/services.js
@@ -115,7 +115,7 @@ export default {
     id: (ids) => ids.join('/'),
   },
   codepen: {
-    regex: /https?:\/\/codepen\.io\/([^\/\?\&]*)\/pen\/([^\/\?\&]*)/,
+    regex: /https?:\/\/codepen\.io\/([^\/\?\&]*)\/(?:pen|details|full|embed)\/([^\/\?\&]*)(?:.*)/,
     embedUrl: 'https://codepen.io/<%= remote_id %>?height=300&theme-id=0&default-tab=css,result&embed-version=2',
     html: "<iframe height='300' scrolling='no' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'></iframe>",
     height: 300,


### PR DESCRIPTION
Changed regex from 

`/https?:\/\/codepen\.io\/([^\/\?\&]*)\/pen\/([^\/\?\&]*)/`

to

`/https?:\/\/codepen\.io\/([^\/\?\&]*)\/(?:pen|details|full|embed)\/([^\/\?\&]*)(?:.*)/`

This will handle the cases when user pastes CodePen URLs of the form:

1.  https://codepen.io/user/full/hash
2.  https://codepen.io/user/details/hash
3.  https://codepen.io/user/pen/hash (Earlier regex only handled this)
4.  https://codepen.io/user/embed/hash

Additionally, the new regex will handle URLs like `https://codepen.io/user/embed/hash/?height=300&theme-id=22934&default-tab=js,result` (although the parameters will not be respected) or those containing any `/` at the end.
