### PR TITLE
Embed Vimeo if passed an embed URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/embed",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "keywords": [
     "codex editor",
     "embed",

--- a/src/services.js
+++ b/src/services.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-useless-escape */
 export default {
   vimeo: {
-    regex: /(?:http[s]?:\/\/)?(?:www.)?vimeo\.co(?:.+\/([^\/]\d+)(?:#t=[\d]+)?s?$)/,
+    regex: /(?:http[s]?:\/\/)?(?:(www|player).)?vimeo\.co(?:.+\/([^\/]\d+)(?:#t=[\d]+)?s?$)/,
     embedUrl: 'https://player.vimeo.com/video/<%= remote_id %>?title=0&byline=0',
     html: '<iframe style="width:100%;" height="320" frameborder="0"></iframe>',
     height: 320,

--- a/test/services.js
+++ b/test/services.js
@@ -42,7 +42,8 @@ describe('Services Regexps', () => {
 
     const urls = [
       {source: 'https://vimeo.com/289836809', embed: 'https://player.vimeo.com/video/289836809?title=0&byline=0'},
-      {source: 'https://vimeo.com/280712228', embed: 'https://player.vimeo.com/video/280712228?title=0&byline=0'}
+      {source: 'https://www.vimeo.com/280712228', embed: 'https://player.vimeo.com/video/280712228?title=0&byline=0'}
+      {source: 'https://player.vimeo.com/video/504749530', embed: 'https://player.vimeo.com/video/504749530?title=0&byline=0'}
     ];
 
     urls.forEach(url => {


### PR DESCRIPTION
Private Vimeo videos can still be embedded with proper settings, but the REGEX doesn't catch these URL's that look like [`https://player.vimeo.com/video/504749530`.](https://player.vimeo.com/video/504749530.) This PR will catch those and turn them into embeds on EditorJS, as expected.