### PR TITLE
Ignore 'list' parameter if it's known to break YouTube embed

### DIFF
--- a/src/services.js
+++ b/src/services.js
@@ -42,6 +42,12 @@ export default {
             return null;
           }
 
+          if (value === 'LL' 
+            || value.startsWith('RDMM')
+            || value.startsWith('FL')) {
+            return null;
+          }
+
           return `${paramsMap[name]}=${value}`;
         })
         .filter(param => !!param);

--- a/test/services.js
+++ b/test/services.js
@@ -22,7 +22,7 @@ describe('Services Regexps', () => {
       { source: 'https://www.youtube.com/watch?v=wZZ7oFKsKzY&t=120', embed: 'https://www.youtube.com/embed/wZZ7oFKsKzY?start=120' },
       { source: 'https://www.youtube.com/embed/_q51LZ2HpbE?list=PLLy6qvPKpdlV3OAw00EuZMoYPz4pYuwuN', embed: 'https://www.youtube.com/embed/_q51LZ2HpbE?list=PLLy6qvPKpdlV3OAw00EuZMoYPz4pYuwuN' },
       { source: 'https://www.youtube.com/watch?time_continue=173&v=Nd9LbCWpHp8', embed: 'https://www.youtube.com/embed/Nd9LbCWpHp8?start=173' },
-      { source: 'https://www.youtube.com/watch?v=efBBjIK3b8I&list=LL&t=1337s', embed: 'https://www.youtube.com/embed/efBBjIK3b8I?start=1337' },
+      { source: 'https://www.youtube.com/watch?v=efBBjIK3b8I&list=LL&t=1337', embed: 'https://www.youtube.com/embed/efBBjIK3b8I?start=1337' },
       { source: 'https://www.youtube.com/watch?v=yQUeAin7fII&list=RDMMnMXCzscqi_M', embed: 'https://www.youtube.com/embed/yQUeAin7fII?' },
       { source: 'https://www.youtube.com/watch?v=3kw2sttGXMI&list=FLgc4xqIMDoiP4KOTFS21TJA', embed: 'https://www.youtube.com/embed/3kw2sttGXMI?' },
     ];

--- a/test/services.js
+++ b/test/services.js
@@ -21,7 +21,10 @@ describe('Services Regexps', () => {
     const urls = [
       { source: 'https://www.youtube.com/watch?v=wZZ7oFKsKzY&t=120', embed: 'https://www.youtube.com/embed/wZZ7oFKsKzY?start=120' },
       { source: 'https://www.youtube.com/embed/_q51LZ2HpbE?list=PLLy6qvPKpdlV3OAw00EuZMoYPz4pYuwuN', embed: 'https://www.youtube.com/embed/_q51LZ2HpbE?list=PLLy6qvPKpdlV3OAw00EuZMoYPz4pYuwuN' },
-      { source: 'https://www.youtube.com/watch?time_continue=173&v=Nd9LbCWpHp8', embed: 'https://www.youtube.com/embed/Nd9LbCWpHp8?start=173' }
+      { source: 'https://www.youtube.com/watch?time_continue=173&v=Nd9LbCWpHp8', embed: 'https://www.youtube.com/embed/Nd9LbCWpHp8?start=173' },
+      { source: 'https://www.youtube.com/watch?v=efBBjIK3b8I&list=LL&t=1337s', embed: 'https://www.youtube.com/embed/efBBjIK3b8I?start=1337' },
+      { source: 'https://www.youtube.com/watch?v=yQUeAin7fII&list=RDMMnMXCzscqi_M', embed: 'https://www.youtube.com/embed/yQUeAin7fII?' },
+      { source: 'https://www.youtube.com/watch?v=3kw2sttGXMI&list=FLgc4xqIMDoiP4KOTFS21TJA', embed: 'https://www.youtube.com/embed/3kw2sttGXMI?' },
     ];
 
     urls.forEach(url => {


### PR DESCRIPTION
This PR adds removal of YouTube playlist parameters that are known to break embeds.

Removed playlists:
- LL is liked videos: [example](https://www.youtube.com/watch?v=yQUeAin7fII&list=LL) and [failing embed](https://www.youtube.com/embed/yQUeAin7fII?list=LL);
- RDMM.{0,} is 'My mix': [example just RDMM](https://www.youtube.com/watch?v=HjuSa3_CerU&list=RDMM) and [failing embed](https://www.youtube.com/embed/HjuSa3_CerU?list=RDMM); [example with unique (genre?) id](https://www.youtube.com/watch?v=HjuSa3_CerU&list=RDMMnMXCzscqi_M) and [failing embed](https://www.youtube.com/embed/HjuSa3_CerU?list=RDMMnMXCzscqi_M);
- FL.+ is 'Favorites' playlist on old accounts, they lead to specific user playlist, but embeds with them fail even if it's public: [example](https://www.youtube.com/watch?v=3kw2sttGXMI&list=FLgc4xqIMDoiP4KOTFS21TJA) and [failing embed](https://www.youtube.com/embed/3kw2sttGXMI?list=FLgc4xqIMDoiP4KOTFS21TJA)

Aware of, but not touching:
- RD.+ is any of 'Mixes' you could see on home page, those are public / embed without problems
- _PL.+ seems to be prefix used for all manually-curated playlists_, so chances of those changes removing playlist parameter where it's actually needed is low