### PR TITLE
fixed youtube regex #119

### DIFF
--- a/src/services.js
+++ b/src/services.js
@@ -8,7 +8,7 @@ export default {
     width: 580,
   },
   youtube: {
-    regex: /(?:https?:\/\/)?(?:www\.)?(?:(?:youtu\.be\/)|(?:youtube\.com)\/(?:v\/|u\/\w\/|embed\/|watch))(?:(?:\?v=)?([^#&?=]*))?((?:[?&]\w*=\w*)*)/,
+    regex: /(?:https?:\/\/)?(?:www\.)?(?:(?:youtu\.be\/)|(?:youtube\.com)\/(?:v\/|u\/\w\/|embed\/|watch))(?:(?:\?v=)?([^#&?=]*))?((?:[?&]\w*=[\w%+]*))*/,
     embedUrl: 'https://www.youtube.com/embed/<%= remote_id %>',
     html: '<iframe style="width:100%;" height="320" frameborder="0" allowfullscreen></iframe>',
     height: 320,


### PR DESCRIPTION
Fixed youtube regex to support channels with special characters like space in them, in current implementation following will not work due to presence of %2, the channel name will be cut out and cause embed to fail

https://www.youtube.com/watch?v=kU9y8rKCe3w&ab_channel=Well%2BGood

